### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     }
   ],
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=5.6",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-dom": "*",
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0"
+    "phpunit/phpunit": "5.0.*"
   },
   "autoload": {
     "psr-4": { "RESO\\" : "lib/" }


### PR DESCRIPTION
Phpunit 7 requires php version greater or equal 7.1 , it should be 5.0.* also PHP 5.3,5.4.5.5 versions are unsupported