### PR TITLE
Psr4 autoloading compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ Simple usage looks like:
 
 ```php
 // Set the variables
-RESO\RESO::setClientId('YOUR_CLIENT_ID');
-RESO\RESO::setClientSecret('YOUR_CLIENT_SECRET');
-RESO\RESO::setAPIAuthUrl('https://op.api.crmls.org/identity/connect/authorize');
-RESO\RESO::setAPITokenUrl('https://op.api.crmls.org/identity/connect/token');
-RESO\RESO::setAPIRequestUrl('https://h.api.crmls.org/RESO/OData/');
+RESO\Reso::setClientId('YOUR_CLIENT_ID');
+RESO\Reso::setClientSecret('YOUR_CLIENT_SECRET');
+RESO\Reso::setAPIAuthUrl('https://op.api.crmls.org/identity/connect/authorize');
+RESO\Reso::setAPITokenUrl('https://op.api.crmls.org/identity/connect/token');
+RESO\Reso::setAPIRequestUrl('https://h.api.crmls.org/RESO/OData/');
 // Authorize user
 $auth_code = RESO\OpenIDConnect::authorize('YOUR_USERNAME', 'YOUR_PASSWORD', 'https://openid.reso.org/', 'ODataApi');
 // Get access token
-RESO\RESO::setAccessToken(RESO\OpenIDConnect::requestAccessToken($auth_code, 'https://openid.reso.org/', 'ODataApi'));
+RESO\Reso::setAccessToken(RESO\OpenIDConnect::requestAccessToken($auth_code, 'https://openid.reso.org/', 'ODataApi'));
 // Set the Accept header (if needed)
 RESO\Request::setAcceptType("json");
 // Retrieve top 10 properties from the RESO API endpoint
@@ -88,9 +88,9 @@ The SDK has a built-in logger for debug / testing purposes. Usage:
 
 ```php
 // Set logging
-RESO\RESO::setLogEnabled(true); // enables logging in general. Default: false.
-RESO\RESO::setLogConsole(true); // enables log messages to console.
-RESO\RESO::setLogFile(true); // enabled log messages to be written to log file.
+RESO\Reso::setLogEnabled(true); // enables logging in general. Default: false.
+RESO\Reso::setLogConsole(true); // enables log messages to console.
+RESO\Reso::setLogFile(true); // enabled log messages to be written to log file.
 
 ```
 

--- a/examples/cli-example/bridge.php
+++ b/examples/cli-example/bridge.php
@@ -1,0 +1,19 @@
+#!/usr/bin/php
+<?php
+
+// This PHP CLI script demonstrates RESO API login and request functionality using the RESO-PHP SDK
+require_once("../../init.php");
+require_once("config.php");
+
+RESO\Reso::setDataset('test'); //set in config.php
+RESO\Reso::setAccessToken($server_token);
+RESO\Reso::setAPIRequestUrl('https://api.bridgedataoutput.com/api/v2/OData/'.\RESO\Reso::getDataset());
+
+// Retrieve top 10 properties from the RESO API endpoint
+$data = RESO\Request::request("Property?\$top=10", "json", true);
+
+// Display records
+echo "Records retrieved from RESO API: ".count($data["value"])."\n\nRecords:\n";
+print_r($data);
+
+return true;

--- a/examples/cli-example/config.php
+++ b/examples/cli-example/config.php
@@ -24,6 +24,9 @@ $client_secret = "";
 // Redirect URI
 $redirect_uri = "";
 
+// bridge server token
+$server_token = "";
+
 // Scope
 $scope = "ODataApi";
 

--- a/examples/cli-example/example-cli.php
+++ b/examples/cli-example/example-cli.php
@@ -6,22 +6,22 @@ require_once("../../init.php");
 require_once("config.php");
 
 // Set logging
-RESO\RESO::setLogEnabled(true);
-RESO\RESO::setLogConsole(true);
-RESO\RESO::setLogFile(true);
+RESO\Reso::setLogEnabled(true);
+RESO\Reso::setLogConsole(true);
+RESO\Reso::setLogFile(true);
 
 // Set the variables
-RESO\RESO::setClientId($client_id);
-RESO\RESO::setClientSecret($client_secret);
-RESO\RESO::setAPIAuthUrl($api_auth_url);
-RESO\RESO::setAPITokenUrl($api_token_url);
-RESO\RESO::setAPIRequestUrl($api_request_url);
+RESO\Reso::setClientId($client_id);
+RESO\Reso::setClientSecret($client_secret);
+RESO\Reso::setAPIAuthUrl($api_auth_url);
+RESO\Reso::setAPITokenUrl($api_token_url);
+RESO\Reso::setAPIRequestUrl($api_request_url);
 
 // Authorize user
 $auth_code = RESO\OpenIDConnect::authorize($auth_username, $auth_password, $redirect_uri, $scope);
 
 // Get access token
-RESO\RESO::setAccessToken(RESO\OpenIDConnect::requestAccessToken($auth_code, $redirect_uri, $scope));
+RESO\Reso::setAccessToken(RESO\OpenIDConnect::requestAccessToken($auth_code, $redirect_uri, $scope));
 
 // Set the Accept header (if needed)
 RESO\Request::setAcceptType("json");

--- a/examples/web-callback-example/callback.php
+++ b/examples/web-callback-example/callback.php
@@ -5,16 +5,16 @@ require_once("../../init.php");
 require_once("config.php");
 
 // Set variables
-RESO\RESO::setClientId($client_id);
-RESO\RESO::setClientSecret($client_secret);
-RESO\RESO::setAPITokenUrl($api_token_url);
-RESO\RESO::setAPIRequestUrl($api_request_url);
+RESO\Reso::setClientId($client_id);
+RESO\Reso::setClientSecret($client_secret);
+RESO\Reso::setAPITokenUrl($api_token_url);
+RESO\Reso::setAPIRequestUrl($api_request_url);
 
 if($_GET['code']) {
     echo "Logged in to RESO API endpoint!";
 
     // Set access token
-    RESO\RESO::setAccessToken($_GET['code']);
+    RESO\Reso::setAccessToken($_GET['code']);
 
     // Do requests ...
 }

--- a/examples/web-callback-example/index.php
+++ b/examples/web-callback-example/index.php
@@ -5,10 +5,10 @@ require_once("../../init.php");
 require_once("config.php");
 
 // Set the variables
-RESO\RESO::setClientId($client_id);
-RESO\RESO::setClientSecret($client_secret);
-RESO\RESO::setAPIAuthUrl($api_auth_url);
-RESO\RESO::setAPITokenUrl($api_token_url);
+RESO\Reso::setClientId($client_id);
+RESO\Reso::setClientSecret($client_secret);
+RESO\Reso::setAPIAuthUrl($api_auth_url);
+RESO\Reso::setAPITokenUrl($api_token_url);
 
 // Redirect user to login page
 header("Location: ".RESO\OpenIDConnect::getLoginUrl($redirect_uri, $scope));

--- a/examples/web-example/index.php
+++ b/examples/web-example/index.php
@@ -6,11 +6,11 @@ require_once(dirname(__FILE__) . '/../../init.php');
 require_once(dirname(__FILE__) . '/config.php');
 
 // Set variables
-RESO\RESO::setClientId($client_id);
-RESO\RESO::setClientSecret($client_secret);
-RESO\RESO::setAPIAuthUrl($api_auth_url);
-RESO\RESO::setAPITokenUrl($api_token_url);
-RESO\RESO::setAPIRequestUrl($api_request_url);
+RESO\Reso::setClientId($client_id);
+RESO\Reso::setClientSecret($client_secret);
+RESO\Reso::setAPIAuthUrl($api_auth_url);
+RESO\Reso::setAPITokenUrl($api_token_url);
+RESO\Reso::setAPIRequestUrl($api_request_url);
 
 // Set the Accept header (if needed)
 RESO\Request::setAcceptType("json");
@@ -53,7 +53,7 @@ echo '<html>
         </head>
         <center><h1><img src="https://www.reso.org/wp-content/uploads/2016/10/RESO.png" width="160" height="40"> API PHP SDK Web Example</h1>';
 
-        echo '<h4>RESO API PHP SDK version: '.\RESO\RESO::getApiSdkVersion().'<br/>PHP version: '.phpversion().'</h4></center>';
+        echo '<h4>RESO API PHP SDK version: '.\RESO\Reso::getApiSdkVersion().'<br/>PHP version: '.phpversion().'</h4></center>';
 
 // We do have a login request - process it
 if($_POST && isset($_POST['username']) && isset($_POST['password'])) {
@@ -64,7 +64,7 @@ if($_POST && isset($_POST['username']) && isset($_POST['password'])) {
     // Get auth token
     $token = RESO\OpenIDConnect::requestAccessToken($auth_code, $redirect_uri, $scope);
     if(!$token) die("Could not obtain token.");
-    RESO\RESO::setAccessToken($token);
+    RESO\Reso::setAccessToken($token);
 
     // Login successful
     echo '<center><h2>Login successful!</h2>
@@ -97,7 +97,7 @@ else if($_POST && isset($_POST['token']) && strlen($_POST['token']) > 0 && isset
             <h1>Request output:</h1>';
 
     // Set the access token
-    RESO\RESO::setAccessToken($_POST['token']);
+    RESO\Reso::setAccessToken($_POST['token']);
 
     // Process the request
     $data = RESO\Request::request($_POST['request'], $_POST['format']);

--- a/lib/Error/Base.php
+++ b/lib/Error/Base.php
@@ -18,7 +18,7 @@ abstract class Base extends Exception
             $this->requestId = $httpHeaders['Request-Id'];
         }
 
-        \RESO\RESO::logMessage("EXCEPTION: ".$message);
+        \RESO\Reso::logMessage("EXCEPTION: ".$message);
     }
 
     public function getHttpStatus()

--- a/lib/Log/Base.php
+++ b/lib/Log/Base.php
@@ -5,16 +5,16 @@ namespace RESO\Log;
 abstract class Base
 {
     public static function logMessage($message) {
-        if(!\RESO\RESO::getLogEnabled()) {
+        if(!\RESO\Reso::getLogEnabled()) {
             return false;
         }
 
-        if(\RESO\RESO::getLogConsole()) {
+        if(\RESO\Reso::getLogConsole()) {
             self::logConsole($message);
         }
 
-        if(\RESO\RESO::getLogFile() && \RESO\RESO::getLogFileName()) {
-            self::logFile(\RESO\RESO::getLogFileName(), $message);
+        if(\RESO\Reso::getLogFile() && \RESO\Reso::getLogFileName()) {
+            self::logFile(\RESO\Reso::getLogFileName(), $message);
         }
     }
 

--- a/lib/OpenIDConnect.php
+++ b/lib/OpenIDConnect.php
@@ -22,11 +22,11 @@ class OpenIDConnect
      */
     public static function authorize($username, $password, $redirect_uri, $scope = "ODataApi")
     {
-        \RESO\RESO::logMessage("Initiating RESO API authorization.");
+        \RESO\Reso::logMessage("Initiating RESO API authorization.");
 
         // Get variables
-        $api_auth_url = \RESO\RESO::getAPIAuthUrl();
-        $client_id = \RESO\RESO::getClientId();
+        $api_auth_url = \RESO\Reso::getAPIAuthUrl();
+        $client_id = \RESO\Reso::getClientId();
 
         $curl = new \RESO\HttpClient\CurlClient();
 
@@ -108,12 +108,12 @@ class OpenIDConnect
      */
     public static function requestAccessToken($auth_code, $redirect_uri, $scope = "ODataApi")
     {
-        \RESO\RESO::logMessage("Sending authorization request to retrieve access token.");
+        \RESO\Reso::logMessage("Sending authorization request to retrieve access token.");
 
         // Get variables
-        $api_token_url = \RESO\RESO::getAPITokenUrl();
-        $client_id = \RESO\RESO::getClientId();
-        $client_secret = \RESO\RESO::getClientSecret();
+        $api_token_url = \RESO\Reso::getAPITokenUrl();
+        $client_id = \RESO\Reso::getClientId();
+        $client_secret = \RESO\Reso::getClientSecret();
 
         $curl = new \RESO\HttpClient\CurlClient();
 
@@ -141,13 +141,13 @@ class OpenIDConnect
      */
     public static function requestRefreshToken()
     {
-        \RESO\RESO::logMessage("Requesting refresh token.");
+        \RESO\Reso::logMessage("Requesting refresh token.");
 
         // Get variables
-        $access_token = \RESO\RESO::getAccessToken();
-        $api_token_url = \RESO\RESO::getAPITokenUrl();
-        $client_id = \RESO\RESO::getClientId();
-        $client_secret = \RESO\RESO::getClientSecret();
+        $access_token = \RESO\Reso::getAccessToken();
+        $api_token_url = \RESO\Reso::getAPITokenUrl();
+        $client_id = \RESO\Reso::getClientId();
+        $client_secret = \RESO\Reso::getClientSecret();
 
         $curl = new \RESO\HttpClient\CurlClient();
 
@@ -177,8 +177,8 @@ class OpenIDConnect
     public static function getLoginUrl($redirect_uri, $scope = "ODataApi")
     {
         // Get variables
-        $api_auth_url = \RESO\RESO::getAPIAuthUrl();
-        $client_id = \RESO\RESO::getClientId();
+        $api_auth_url = \RESO\Reso::getAPIAuthUrl();
+        $client_id = \RESO\Reso::getClientId();
 
         // Authentication request parameters
         $params = array(

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -22,11 +22,11 @@ abstract class Request
      */
     public static function request($request, $output_format = "xml", $decode_json = false)
     {
-        \RESO\RESO::logMessage("Sending request '".$request."' to RESO API.");
+        \RESO\Reso::logMessage("Sending request '".$request."' to RESO API.");
 
         // Get variables
-        $api_request_url = \RESO\RESO::getAPIRequestUrl();
-        $token = \RESO\RESO::getAccessToken();
+        $api_request_url = \RESO\Reso::getAPIRequestUrl();
+        $token = \RESO\Reso::getAccessToken();
 
         if(!in_array($output_format, self::$validOutputFormats)) {
             $output_format = "json";
@@ -90,11 +90,11 @@ abstract class Request
      */
     public static function requestPost($request, $params = array())
     {
-        \RESO\RESO::logMessage("Sending POST request '".$request."' to RESO API.");
+        \RESO\Reso::logMessage("Sending POST request '".$request."' to RESO API.");
 
         // Get variables
-        $api_request_url = \RESO\RESO::getAPIRequestUrl();
-        $token = \RESO\RESO::getAccessToken();
+        $api_request_url = \RESO\Reso::getAPIRequestUrl();
+        $token = \RESO\Reso::getAccessToken();
 
         $curl = new \RESO\HttpClient\CurlClient();
 
@@ -146,7 +146,7 @@ abstract class Request
      * @return True / false output saved to file.
      */
     public static function requestToFile($file_name, $request, $output_format = "xml", $overwrite = false, $accept_format = "json") {
-        \RESO\RESO::logMessage("Sending request '".$request."' to RESO API and storing output to file '".$file_name."'.");
+        \RESO\Reso::logMessage("Sending request '".$request."' to RESO API and storing output to file '".$file_name."'.");
 
         if(!$overwrite && is_file($file_name)) {
             throw new Error\Reso("File '".$file_name."' already exists. Use variable 'overwrite' to overwrite the output file.");
@@ -158,17 +158,17 @@ abstract class Request
 
         $output_data = self::request($request, $output_format, false, $accept_format);
         if(!$output_data) {
-            \RESO\RESO::logMessage("Request output save to file failed - empty or erroneous data.");
+            \RESO\Reso::logMessage("Request output save to file failed - empty or erroneous data.");
             return false;
         }
 
         file_put_contents($file_name, $output_data);
         if(!is_file($file_name)) {
-            \RESO\RESO::logMessage("Request output save to file failed - could not create output file.");
+            \RESO\Reso::logMessage("Request output save to file failed - could not create output file.");
             return false;
         }
 
-        \RESO\RESO::logMessage("Request output save to file succeeded.");
+        \RESO\Reso::logMessage("Request output save to file succeeded.");
         return true;
     }
 
@@ -178,7 +178,7 @@ abstract class Request
      * @return Metadata request output.
      */
     public static function requestMetadata() {
-        \RESO\RESO::logMessage("Requesting resource metadata.");
+        \RESO\Reso::logMessage("Requesting resource metadata.");
         return self::request("\$metadata");
     }
 

--- a/lib/Reso.php
+++ b/lib/Reso.php
@@ -10,7 +10,7 @@ use RESO\Error;
  *
  * @package RESO
  */
-class RESO
+class Reso
 {
     // @var string The RESO API client_id to be used for auth and query requests.
     public static $clientId;

--- a/lib/Reso.php
+++ b/lib/Reso.php
@@ -48,6 +48,23 @@ class Reso
     // @var string Log file name enabled / disabled.
     public static $logFileName = 'out.log';
 
+    // @var string dataset
+    public static $dataset = '';
+
+    /**
+     * @return string
+     */
+    public static function getDataset() {
+        return self::$dataset;
+    }
+
+    /**
+     * @param string $dataset
+     */
+    public static function setDataset($dataset) {
+        self::$dataset = $dataset;
+    }
+
     /**
      * @return string The RESO API client_id used for auth and query requests.
      */

--- a/tests/OpenIDConnectTest.php
+++ b/tests/OpenIDConnectTest.php
@@ -8,11 +8,11 @@ final class OpenIdConnectTest extends TestCase
     public function testAuthorize(): void
     {
         require('config.php');
-        RESO\RESO::setClientId($client_id);
-        RESO\RESO::setClientSecret($client_secret);
-        RESO\RESO::setAPIAuthUrl($api_auth_url);
-        RESO\RESO::setAPITokenUrl($api_token_url);
-        RESO\RESO::setAPIRequestUrl($api_request_url);
+        RESO\Reso::setClientId($client_id);
+        RESO\Reso::setClientSecret($client_secret);
+        RESO\Reso::setAPIAuthUrl($api_auth_url);
+        RESO\Reso::setAPITokenUrl($api_token_url);
+        RESO\Reso::setAPIRequestUrl($api_request_url);
         $auth_code = RESO\OpenIDConnect::authorize($auth_username, $auth_password, $redirect_uri, $scope);
         $this->assertNotNull($auth_code);
     }
@@ -20,11 +20,11 @@ final class OpenIdConnectTest extends TestCase
     public function testRequestAccessToken(): void
     {
         require('config.php');
-        RESO\RESO::setClientId($client_id);
-        RESO\RESO::setClientSecret($client_secret);
-        RESO\RESO::setAPIAuthUrl($api_auth_url);
-        RESO\RESO::setAPITokenUrl($api_token_url);
-        RESO\RESO::setAPIRequestUrl($api_request_url);
+        RESO\Reso::setClientId($client_id);
+        RESO\Reso::setClientSecret($client_secret);
+        RESO\Reso::setAPIAuthUrl($api_auth_url);
+        RESO\Reso::setAPITokenUrl($api_token_url);
+        RESO\Reso::setAPIRequestUrl($api_request_url);
         $auth_code = RESO\OpenIDConnect::authorize($auth_username, $auth_password, $redirect_uri, $scope);
         $access_token = RESO\OpenIDConnect::requestAccessToken($auth_code, $redirect_uri, $scope);
         $this->access_token = $access_token;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -8,13 +8,13 @@ final class RequestTest extends TestCase
     public function testRequestMetadata(): void
     {
         require('config.php');
-        RESO\RESO::setClientId($client_id);
-        RESO\RESO::setClientSecret($client_secret);
-        RESO\RESO::setAPIAuthUrl($api_auth_url);
-        RESO\RESO::setAPITokenUrl($api_token_url);
-        RESO\RESO::setAPIRequestUrl($api_request_url);
+        RESO\Reso::setClientId($client_id);
+        RESO\Reso::setClientSecret($client_secret);
+        RESO\Reso::setAPIAuthUrl($api_auth_url);
+        RESO\Reso::setAPITokenUrl($api_token_url);
+        RESO\Reso::setAPIRequestUrl($api_request_url);
         $auth_code = RESO\OpenIDConnect::authorize($auth_username, $auth_password, $redirect_uri, $scope);
-        RESO\RESO::setAccessToken(RESO\OpenIDConnect::requestAccessToken($auth_code, $redirect_uri, $scope));
+        RESO\Reso::setAccessToken(RESO\OpenIDConnect::requestAccessToken($auth_code, $redirect_uri, $scope));
         if(stripos($api_request_url, "h.api.crmls.org") !== false) {
             RESO\Request::setAcceptType("json");
         }
@@ -25,13 +25,13 @@ final class RequestTest extends TestCase
     public function testRequest(): void
     {
         require('config.php');
-        RESO\RESO::setClientId($client_id);
-        RESO\RESO::setClientSecret($client_secret);
-        RESO\RESO::setAPIAuthUrl($api_auth_url);
-        RESO\RESO::setAPITokenUrl($api_token_url);
-        RESO\RESO::setAPIRequestUrl($api_request_url);
+        RESO\Reso::setClientId($client_id);
+        RESO\Reso::setClientSecret($client_secret);
+        RESO\Reso::setAPIAuthUrl($api_auth_url);
+        RESO\Reso::setAPITokenUrl($api_token_url);
+        RESO\Reso::setAPIRequestUrl($api_request_url);
         $auth_code = RESO\OpenIDConnect::authorize($auth_username, $auth_password, $redirect_uri, $scope);
-        RESO\RESO::setAccessToken(RESO\OpenIDConnect::requestAccessToken($auth_code, $redirect_uri, $scope));
+        RESO\Reso::setAccessToken(RESO\OpenIDConnect::requestAccessToken($auth_code, $redirect_uri, $scope));
         if(stripos($api_request_url, "h.api.crmls.org") !== false) {
             RESO\Request::setAcceptType("json");
         }


### PR DESCRIPTION
### Description of the Change

Renamed the RESO class to Reso for psr4 compliance. The class name needs to be the same as the file name, including capitalization. The examples worked fine when I was testing the code, but when I imported into a symfony PHP project, I received the error regarding psr4 autoloading similar to issue: https://github.com/RESOStandards/RESO-WebAPI-Client-PHP/issues/9#issue-615109426

Also added a new cli example for connecting to the bridge web api using only the server token provided by bridge.

### Benefits

Ability to autoload in projects that require psr4 autoloading

### Possible Drawbacks

None

### Verification Process

After importing to symfony project and getting the error. I renamed the class file and dumped the composer autoload file. The result was no errors and I was able to make a connection to the web api and pull property data.

### Applicable Issues

None
